### PR TITLE
Odd length tcpdump packets

### DIFF
--- a/trpr.cpp
+++ b/trpr.cpp
@@ -4556,7 +4556,7 @@ bool TcpdumpEventParser::GetNextPacketEvent(FILE*        inFile,
             theEvent->SetSize(pktSize); 
             double theTime = (((double)hrs) * 3600.0) +
                              (((double)min) * 60.0) +
-                             (double)sec;
+                             sec;
             theEvent->SetTime(theTime);
             theEvent->SetType(PacketEvent::RECEPTION);
             theEvent->InvalidateFlowId();

--- a/trpr.cpp
+++ b/trpr.cpp
@@ -4633,6 +4633,12 @@ unsigned int TcpdumpEventParser::PackHexLine(char* text, char* buf, unsigned int
         }
         else
         {
+            if ((byteCount+1) == buflen)        // handle odd byte count
+            {
+                *buf++ = value & 0x00ff;
+                byteCount += 1;
+            }
+
             // buf is full
             return byteCount;
         }

--- a/trpr.cpp
+++ b/trpr.cpp
@@ -4425,9 +4425,9 @@ bool TcpdumpEventParser::GetNextPacketEvent(FILE*        inFile,
         {
             // Get time, protocol name (pname), and pktSize from header line
             unsigned int hrs, min;
-            float sec;  
+            double sec;  
             // Here we look to see if tcpdump was run with "-e" option 
-            if (5 == sscanf(buffer, "%u:%u:%f %31s > %31s", &hrs, &min, &sec, esrc, edst))
+            if (5 == sscanf(buffer, "%u:%u:%lf %31s > %31s", &hrs, &min, &sec, esrc, edst))
             {
                 /*
                 char* ptr = strstr(buffer, "ethertype");
@@ -4444,7 +4444,7 @@ bool TcpdumpEventParser::GetNextPacketEvent(FILE*        inFile,
                 strcpy(pname, "ether");
                 enet = true;
             }        
-            else if (4 != sscanf(buffer, "%u:%u:%f %31s", &hrs, &min, &sec, pname))
+            else if (4 != sscanf(buffer, "%u:%u:%lf %31s", &hrs, &min, &sec, pname))
             {
                 fprintf(stderr, "trpr: Invalid tcpdump output: \"%s\"\n", buffer);
                 len = MAX_LINE;


### PR DESCRIPTION
Checks if `TcpdumpEventParser::PackHexLine` had an odd number of bytes and handles final byte.

In `TcpdumpEventParser::GetNextPacketEvent` reads seconds as double.

Fixes USNavalResearchLaboratory/trpr#1

